### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ dateparser==1.1.1
 deepspeed==0.7.3
 detoxify==0.5.0
 editdistance==0.6.0
-evaluate==0.2.2
+evaluate==0.3.0
 fastpunct==2.0.2
 forex_python==1.8
 ftfy==6.1.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.